### PR TITLE
Support for 'rotate' attribute in yAxisName

### DIFF
--- a/src/GridMap.js
+++ b/src/GridMap.js
@@ -186,7 +186,7 @@
 			[].push.apply(allData, datasetData);
 		}
 
-		// Now that it hass all the set data across datasets, extracts the values from this by the key
+		// Now that it has all the set data across datasets, extracts the values from this by the key
 		for (setData of allData) {
 			allValues.push(setData[key]);
 		}
@@ -2249,12 +2249,11 @@
 
 					components[config.key] = config.defaultClass;
 				}
-
-				return;
 			}
-
+			else {
 			// If arguments are passed, registers the specified component
 			components[key] = className;
+		}
 		}
 
 		function dependencyController (depDesc) {
@@ -2520,16 +2519,17 @@
 	};
 
 	GridMap.prototype.render = function () {
-		var config = this.config,
+		var instanceAPI = this,
+			config = instanceAPI.config,
 			parentContainer = config.parentContainer,
-			data = this.chartData,
-			//extModules = this.extModules,
+			data = instanceAPI.chartData,
+			//extModules = instanceAPI.extModules,
 			//moduleKey,
 			//extModule,
 			//chart,
 			svg;
 
-		this.svg = svg = parentContainer.append('svg').attr({
+		instanceAPI.svg = svg = parentContainer.append('svg').attr({
 			height: config.height,
 			width: config.width
 		});

--- a/src/GridMap.js
+++ b/src/GridMap.js
@@ -2484,8 +2484,9 @@
 
 	function GridMap (config, chartData) {
 		var _c,
-			merge = utils.merge,
-			chartConf;
+			chartConf,
+			instanceAPI = this,
+			merge = utils.merge;
 
 		if (arguments.length > 1) {
 			_c = config;
@@ -2497,10 +2498,12 @@
 		merge(stubs.getForGridMap(), chartConf);
 		chartConf.parentContainer = utils.getContainer(chartConf.parentContainer);
 
-		this.chartData = chartData;
+		instanceAPI.chartData = chartData;
 
-		this.svg = undefined;
-		this.extModules = {};
+		instanceAPI.svg = undefined;
+		instanceAPI.extModules = {};
+
+		return instanceAPI;
 	}
 
 	GridMap.prototype.constructor = GridMap;

--- a/src/GridMap.js
+++ b/src/GridMap.js
@@ -2586,7 +2586,8 @@
 						'font-weight' : 'bold',
 						'font-family': 'sans-serif',
 						'font-size': '11px'
-					}
+					},
+					rotateValue: 1
 				},
 				gridLine: {
 					postDrawingHook : DEF_FN,

--- a/src/GridMap.js
+++ b/src/GridMap.js
@@ -538,7 +538,7 @@
 			index,
 		 	length,
 		 	thisDimension,
-		 	rotateAxisName = nameConfig.rotateValue,
+		 	rotateAxisNameAngle = utils.toRadian(nameConfig.rotate),
 		 	axisNameMetrics;
 
 		meta.modelSyncDimension = allDimension;
@@ -560,7 +560,7 @@
 		if (this.axisName) {
 			// If axis name is given, allocates space for axis name as well.
 		 	meta.axisNameMetrics = axisNameMetrics = getTextMetrics(this.axisName, config.name.style);
-		 	totalWidth += (rotateAxisName ? axisNameMetrics.height : axisNameMetrics.width) + (config.name.margin || 0);
+		 	totalWidth += ((axisNameMetrics.width * cos(rotateAxisNameAngle)) + (axisNameMetrics.height * sin(rotateAxisNameAngle))) + (config.name.margin || 0);
 		}
 
 		// Reduces the chart body width, so that this axis component can be drawn.
@@ -713,7 +713,9 @@
 	 * suggested. If not drawn it return 0 as value of the keys.
 	 */
 	YAxisModel.prototype.drawAxisName = function (targetGroup, measurement) {
-		var config = this.config,
+		var widthComponent,
+			heightComponent,
+			config = this.config,
 			axisName = this.axisName,
 			meta = this.meta,
 			nameConfig = config.name,
@@ -726,26 +728,27 @@
 				offsetTranslation: 0
 			},
 			textWidth,
-			rotateAxisName = nameConfig.rotateValue,
-			plotItem;
+			rotateValue = nameConfig.rotate,
+			rotateAxisNameAngle = utils.toRadian(rotateValue),
+			plotItem,
+			axisNameMetrics = meta.axisNameMetrics;
 
 		// If axis name is present draw it and return the space taken, else return no space taken
 		if (axisName) {
-			textWidth = meta.axisNameMetrics.width;
-
+			textWidth = (axisNameMetrics.width * cos(rotateAxisNameAngle)) + (axisNameMetrics.height * sin(rotateAxisNameAngle));
+			widthComponent = textWidth / 2 + measurement.x;
+			heightComponent = axisNameMetrics.height / 2 - height / 2;
 			plotItem = targetGroup.append('text')
-			.attr(rotateAxisName ? {
-				transform: 'rotate(' + (rotateAxisName ? -90 : 0) + ')',
-				y: measurement.x,
-				x: - (height / 2 - meta.axisNameMetrics.height / 2)
-			} : {
-				x: measurement.x + textWidth / 2,
-				y: height / 2 - meta.axisNameMetrics.height / 2,
-			}).text(preDrawingHook(axisName)).style(config.name.style);
+			.attr({
+				transform: 'rotate(' + (-rotateValue) + ')',
+				y: (widthComponent * sin(rotateAxisNameAngle)) - (heightComponent * cos(rotateAxisNameAngle)),
+				x: (widthComponent * cos(rotateAxisNameAngle)) + (heightComponent * sin(rotateAxisNameAngle))
+			})
+			.text(preDrawingHook(axisName)).style(config.name.style);
 
 			postDrawingHook(plotItem);
 
-			res.width = margin + (rotateAxisName ? 0 : textWidth);
+			res.width = margin + textWidth;
 			res.offsetTranslation = margin;
 		}
 
@@ -2591,8 +2594,8 @@
 						'font-family': 'sans-serif',
 						'font-size': '11px'
 					},
-					rotateValue: 1
-				},
+					rotate: 90 // default value for rotation of the y-axis
+				}, 
 				gridLine: {
 					postDrawingHook : DEF_FN,
 					style : {

--- a/src/GridMap.js
+++ b/src/GridMap.js
@@ -99,8 +99,12 @@
 	var win = window,
 		doc = win.document,
 		Math = win.Math,
+		sin = Math.sin,
+		cos = Math.cos,
 		ceil = Math.ceil,
 		floor = Math.floor,
+		pi = Math.PI,
+		piBy2 = pi/2,
 		d3 = win.d3,
 		sel = d3.select,
 		hasOwnProp = ({}).hasOwnProperty,
@@ -2869,6 +2873,22 @@
 				}
 
 				return _o;
+			},
+			/*
+			 * Converts an angle from degree to radians.
+			 * @param deg: The input angle in degree to be converted.
+			 * @return Number - Angle in radians.
+			*/
+			toRadian: function (deg) {
+				return deg * pi/180;
+			},
+			/*
+			 * Converts an angle from radians to degree.
+			 * @param rad: The input angle in radians to be converted.
+			 * @return Number - Angle in degrees.
+			*/
+			toDegree: function(rad) {
+				return rad * 180/pi;
 			}
 		};
 	})();

--- a/src/GridMap.js
+++ b/src/GridMap.js
@@ -526,6 +526,7 @@
 	YAxisModel.prototype.allocateComponentSpace = function (allDimension, measurement, componentStackManager) {
 		var max = Number.NEGATIVE_INFINITY,
 			config = this.config,
+			nameConfig = config.name,
 			meta = this.meta,
 			getTextMetrics = utils.getTextMetrics,
 			stackingKeys = componentStackManager.keys,
@@ -533,6 +534,7 @@
 			index,
 		 	length,
 		 	thisDimension,
+		 	rotateAxisName = nameConfig.rotateValue,
 		 	axisNameMetrics;
 
 		meta.modelSyncDimension = allDimension;
@@ -554,7 +556,7 @@
 		if (this.axisName) {
 			// If axis name is given, allocates space for axis name as well.
 		 	meta.axisNameMetrics = axisNameMetrics = getTextMetrics(this.axisName, config.name.style);
-		 	totalWidth += axisNameMetrics.width + (config.name.margin || 0);
+		 	totalWidth += (rotateAxisName ? axisNameMetrics.height : axisNameMetrics.width) + (config.name.margin || 0);
 		}
 
 		// Reduces the chart body width, so that this axis component can be drawn.
@@ -720,20 +722,26 @@
 				offsetTranslation: 0
 			},
 			textWidth,
+			rotateAxisName = nameConfig.rotateValue,
 			plotItem;
 
 		// If axis name is present draw it and return the space taken, else return no space taken
 		if (axisName) {
 			textWidth = meta.axisNameMetrics.width;
 
-			plotItem = targetGroup.append('text').attr({
+			plotItem = targetGroup.append('text')
+			.attr(rotateAxisName ? {
+				transform: 'rotate(' + (rotateAxisName ? -90 : 0) + ')',
+				y: measurement.x,
+				x: - (height / 2 - meta.axisNameMetrics.height / 2)
+			} : {
 				x: measurement.x + textWidth / 2,
 				y: height / 2 - meta.axisNameMetrics.height / 2,
 			}).text(preDrawingHook(axisName)).style(config.name.style);
 
 			postDrawingHook(plotItem);
 
-			res.width = textWidth + margin;
+			res.width = margin + (rotateAxisName ? 0 : textWidth);
 			res.offsetTranslation = margin;
 		}
 
@@ -2251,9 +2259,9 @@
 				}
 			}
 			else {
-			// If arguments are passed, registers the specified component
-			components[key] = className;
-		}
+				// If arguments are passed, registers the specified component
+				components[key] = className;
+			}
 		}
 
 		function dependencyController (depDesc) {


### PR DESCRIPTION
@akash-goswami  In reference to the [issue](https://github.com/akash-goswami/GridMap/issues/1), I have added a support for the attribute 'rotate' that needs to stated under the name property of the y-axisName.

Please validate.

Currently these are the following improvements that needs to be done:

- Rotate should support any valid angle. For now it has issues with angle other than [0,90]. Space management needs to be improved.

- Rotate attribute should be supported in x-axis names and also in the labels of both attribute. So in general rotate functionality will be universal for all of the components.

You might assign me the issue, as I intend to work on it further.