### PR TITLE
GridMap-2: Include preHookDrawing amendments while labels space managements

### DIFF
--- a/src/GridMap.js
+++ b/src/GridMap.js
@@ -235,7 +235,9 @@
 	 */
 	AxisModel.prototype.updatePreDrawingSpace = function (controller) {
 		var getTextMetrics = utils.getTextMetrics,
-			labelStyle = this.config.label.style;
+			labelConfig = this.config.label,
+			labelStyle = labelConfig.style,
+			labelPreDrawingHook = labelConfig.preDrawingHook;
 
 		// Aks for the the dependenies that are needed to calculate the component space.
 		// Details of all the dependencies which can be invoked is listed at top.
@@ -250,7 +252,7 @@
 
 				for (; index < length; index++) {
 					// Gets all the model texts which will be plotted.
-					allDimension.push(getTextMetrics(model[index], labelStyle));
+					allDimension.push(getTextMetrics(labelPreDrawingHook(model[index]), labelStyle));
 				}
 
 				// Relegates the call to the child derived class, so that it manages it's own parts


### PR DESCRIPTION
In reference to the [bug](https://github.com/akash-goswami/GridMap/issues/5), I think this would be the fix.
 - On appending texts using prehook, there was overlapping issues for the labels previously.
 - Now it uses an extra function call to get the changes in preDrawHook being reflected during the space management.

@akash-goswami Please validate.