### PR TITLE
Fix multiple calls in preHook functions

### DIFF
--- a/src/GridMap.js
+++ b/src/GridMap.js
@@ -346,7 +346,7 @@
 
 		if (this.axisName) {
 			// If axis name is given, allocates space for axis name as well.
-	 		meta.axisNameMetrics = axisNameMetrics = getTextMetrics(this.axisName, config.name.style);
+	 		meta.axisNameMetrics = axisNameMetrics = getTextMetrics(this.preHookedAxisName, config.name.style);
 	 		totalHeight += axisNameMetrics.height + (config.name.margin || 0);
 		}
 
@@ -460,7 +460,11 @@
 	 * suggested
 	 */
 	XAxisModel.prototype.drawAxisLabels = function (targetGroup, measurement) {
-		var model = this.model,
+		var model = this.getModel(),
+			preHookedModel = this.getPreHookedModel(),
+			textFN = function () {
+				return preHookedModel[arguments[1]];
+			},
 			config = this.config,
 			meta = this.meta,
 			modelSize = model.length,
@@ -468,7 +472,6 @@
 			labelConfig = config.label,
 			margin = labelConfig.margin || 0,
 			y = measurement.y,
-			preDrawingHook = labelConfig.preDrawingHook,
 			postDrawingHook = labelConfig.postDrawingHook,
 			labelGroup,
 			allText;
@@ -483,7 +486,7 @@
 			dx: '-0.25em',
 			x : function (d, i) { return (i *  blockSize) + (blockSize / 2); },
 			y: y + margin + meta.maxLabelHeight / 2
-		}).text(preDrawingHook).style(labelConfig.style);
+		}).text(textFN).style(labelConfig.style);
 
 		// Once all text are plotted in DOM, call the hook callback by passing all the SVGElements
 		postDrawingHook(allText);
@@ -507,7 +510,6 @@
 			axisName = this.axisName,
 			meta = this.meta,
 			nameConfig = config.name,
-			preDrawingHook = nameConfig.preDrawingHook,
 			postDrawingHook = nameConfig.postDrawingHook,
 			margin = nameConfig.margin || 0,
 			width = measurement.width,
@@ -522,7 +524,7 @@
 			plotItem = targetGroup.append('text').attr({
 				x: width / 2,
 				y: measurement.y + margin,
-			}).text(preDrawingHook(axisName)).style(config.name.style);
+			}).text(this.preHookedAxisName).style(config.name.style);
 
 			postDrawingHook(plotItem);
 

--- a/src/GridMap.js
+++ b/src/GridMap.js
@@ -205,6 +205,31 @@
 	};
 
 	/*
+	 * Applies prehooks to the data model.
+	 * Which would be useful in space management and drawing implementations.
+	 * Saving this seperately would help not to diturb the sanity of the axis model.
+	 *
+	 * @return {Array} - Array of values after applying the prehook.
+	*/
+	AxisModel.prototype.preHookModel = function () {
+		var axisModel = this,
+			model = axisModel.model,
+			labelConfig = axisModel.config.label,
+			preDrawingHook = labelConfig.preDrawingHook;
+
+		return model.map(preDrawingHook);
+	};
+
+	/*
+	 * Retrieves the preHooked model, once created.
+	 *
+	 * @return {Array} - The preHooked model for the axis.
+	*/
+	AxisModel.prototype.getPreHookedModel = function () {
+		return this.preHookedModel;
+	};
+
+	/*
 	 * Retrieves the model, once created.
 	 * What is model for axes? See AXIS MODEL AND HOOKS at top.
 	 *

--- a/src/GridMap.js
+++ b/src/GridMap.js
@@ -594,7 +594,7 @@
 
 		if (this.axisName) {
 			// If axis name is given, allocates space for axis name as well.
-		 	meta.axisNameMetrics = axisNameMetrics = getTextMetrics(this.axisName, config.name.style);
+		 	meta.axisNameMetrics = axisNameMetrics = getTextMetrics(this.preHookedAxisName, config.name.style);
 		 	totalWidth += ((axisNameMetrics.width * cos(rotateAxisNameAngle)) + (axisNameMetrics.height *
 		 		sin(rotateAxisNameAngle))) + (config.name.margin || 0);
 		}
@@ -705,7 +705,11 @@
 	 * suggested
 	 */
 	YAxisModel.prototype.drawAxisLabels = function (targetGroup, measurement) {
-		var model = this.model,
+		var model = this.getModel(),
+			preHookedModel = this.getPreHookedModel(),
+			textFN = function () {
+				return preHookedModel[arguments[1]];
+			},
 			config = this.config,
 			meta = this.meta,
 			labelConfig = config.label,
@@ -713,7 +717,6 @@
 			margin = labelConfig.margin || 0,
 			modelSize = model.length,
 			blockSize = measurement.height / modelSize,
-			preDrawingHook = labelConfig.preDrawingHook,
 			postDrawingHook = labelConfig.postDrawingHook,
 			modelSyncDimension = meta.modelSyncDimension,
 			labelGroup,
@@ -729,7 +732,7 @@
 			dy: '-0.25em',
 			x: x + meta.maxLabelWidth / 2,
 			y : function (d, i) { return (i *  blockSize) + (blockSize / 2) + modelSyncDimension[i].height / 2; }
-		}).text(preDrawingHook).style(labelConfig.style);
+		}).text(textFN).style(labelConfig.style);
 
 		// Once all text are plotted in DOM, call the hook callback by passing all the SVGElements
 		postDrawingHook(allText);
@@ -755,7 +758,6 @@
 			axisName = this.axisName,
 			meta = this.meta,
 			nameConfig = config.name,
-			preDrawingHook = nameConfig.preDrawingHook,
 			postDrawingHook = nameConfig.postDrawingHook,
 			margin = nameConfig.margin || 0,
 			height = measurement.height,
@@ -781,7 +783,7 @@
 				y: (widthComponent * sin(rotateAxisNameAngle)) - (heightComponent * cos(rotateAxisNameAngle)),
 				x: (widthComponent * cos(rotateAxisNameAngle)) + (heightComponent * sin(rotateAxisNameAngle))
 			})
-			.text(preDrawingHook(axisName)).style(config.name.style);
+			.text(this.preHookedAxisName).style(config.name.style);
 
 			postDrawingHook(plotItem);
 


### PR DESCRIPTION
In reference to the [bug](https://github.com/akash-goswami/GridMap/issues/5),
- The prehook functions are called only once. The results are stored as the property of the instance for future reference.

- SpaceManagement is extended to even pre-hooking the axis names too.

Hey @akash-goswami Just validate once.